### PR TITLE
MARKET-4849: Hmac Endpoint Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GET /provisioning/user-profiles HTTP/1.1
 Accept: application/json
 Authorization: AccessKey e63ca6a9ca2e4db2bc13b741e7488437:Ysvt4LcqSnmIjvPbolVm2bS/zDXdqnYBtgtG+lWMlLI6uJp1MJiW34OVNtYrYA/B+6T/NDqhqFxbtlvuIFBliw==
 Date: Wed, 26 Jun 2019 17:38:30 GMT
-Host: gateway.ncrplatform.com
+Host: api.ncr.com
 ```
 
 The scheme used in the `Authorization` header is `AccessKey <shared-key>:<hmac>`.
@@ -144,6 +144,6 @@ If you are adding a new language there are some requirements around how it is st
    - An example GET request
    - An example POST request
    
-Visit the `/js` and `/python` folders for examples of these files - the example GET and POST request utilize the Sites API.
+Visit the `/js` and `/python` folders for examples of these files - the example GET and POST request utilize the Security API.
 
 Lastly, be sure to update the main README.md in the [Examples](#examples) section to add a new table element for your new code. 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ In this repository we've provided a couple examples in different languages. For 
 To use these functions, you will need your Shared Key, Secret Key, and Organization.
 
 | [JS Examples](https://github.com/NCR-Corporation/ncr-bsp-hmac/tree/main/js) | [Python Examples](https://github.com/NCR-Corporation/ncr-bsp-hmac/tree/main/python) | [PowerShell Examples](https://github.com/NCR-Corporation/ncr-bsp-hmac/tree/main/powershell) | [Go Examples](https://github.com/NCR-Corporation/ncr-bsp-hmac/tree/main/go)
-| --------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [Java Examples](https://github.com/NCR-Corporation/ncr-bsp-hmac/tree/main/java) | [Dotnet Examples](https://github.com/NCR-Corporation/ncr-bsp-hmac/tree/main/dotnet) | ------------------------------------------------------------------------------------------- |
 
 ## Support
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -50,50 +50,8 @@ _This code uses Dotnet 5_
    //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
    //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
    //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
-   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
-   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
-   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
-   //            "description": "Technical AAL Server user.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
-   //             "restrictImplies": false
    //       }
-   //    ]
-   //  }
-   //}
+   //       ... Roles List ...
    ```
 
    ```console
@@ -107,90 +65,9 @@ _This code uses Dotnet 5_
    //      "maxSessionTime": 900,
    //      "remainingTime": 900,
    //      "authorities": [
-   //      "NEP_IDENTITY_VIEWER",
-   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
-   //      "DELIVERY_SCRUBBER",
-   //      "R1_DC_APPLICATION_ROLE",
-   //      "R1_DC_OFFER_USER",
-   //      "R1_ORDER_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_WRITER",
-   //      "R1_ORDER_SITE_VIEWER",
-   //      "TDM_ADMIN",
-   //      "NEP_CONFIG_SETTINGS_VIEWER",
-   //      "CDM_CUSTOMER_VIEWER",
-   //      "DELIVERY_THRESHOLD_VIEWER",
-   //      "R1_CATALOG_VIEWER",
-   //      "NEP_APPLICATION_SPECTATOR",
-   //      "PES_GET",
-   //      "R1_TDM_UPLOAD",
-   //      "R1_ORDER_LOCK_ADMIN",
-   //      "SITE_READ",
-   //      "NEP_ORGANIZATION_VIEWER",
-   //      "CDM_PARTNER_CONSUMER_SEARCH",
-   //      "DYNAMIC_TYPE_VIEWER",
-   //      "R1_DC_PROVIDER",
-   //      "NEP_STORAGE_OBJECT_MODIFIER",
-   //      "R1_SUPPORT_CLIPPER",
-   //      "PES_END_OF_DAY",
-   //      "R1_CATALOG_APPLICATION",
-   //      "TDM_UPLOAD",
-   //      "R1_DC_OFFER_SUPERUSER",
-   //      "PES_ERROR",
-   //      "NEP_STORAGE_CONTAINER_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
-   //      "R1_ORDER_VIEWER",
-   //      "SITE_IMPORT",
-   //      "CDM_CUSTOMER_MODIFIER",
-   //      "R1_ORDER",
-   //      "PES_VOID",
-   //      "DELIVERY_UPDATER",
-   //      "R1_DC_APPLICATION",
-   //      "NEP_DEPLOYMENT_VIEWER",
-   //      "TDM_WRITE",
-   //      "R1_DC_POS",
-   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
-   //      "IAS_SINGLE_ITEM_VIEWER",
-   //      "IAS_MULTIPLE_ITEMS_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
-   //      "SITE_CREATE",
-   //      "R1_DC_VIEWER",
-   //      "R1_SUPPORT_USER",
-   //      "CDM_CUSTOMER_SEARCH",
-   //      "PES_FINALIZE",
-   //      "CDM_PARTNER_CONSUMER_CREATE",
-   //      "NEP_APIMANAGEMENT_VIEWER",
-   //      "OCP_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_ADMINISTRATOR",
-   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_GRANT_VIEWER",
-   //      "DELIVERY_REQUESTOR",
-   //      "NEP_JOURNALING_VIEWER",
-   //      "R1_ORDER_ADMINISTRATOR",
-   //      "CDM_ADMINISTRATOR",
-   //      "NEP_STORAGE_OBJECT_VIEWER",
-   //      "TDM_READ",
-   //      "NEP_EMAIL_SENDER",
-   //      "R1_SUPPORT_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIBER",
-   //      "R1_DC_ADMINISTRATOR",
-   //      "DX_SANDBOX",
-   //      "TDM_UPDATE",
-   //      "R1_TDM_ADMIN",
-   //      "R1_CATALOG_ADMINISTRATOR",
-   //      "NEP_JOURNALING_WRITER",
-   //      "CDM_CUSTOMER_DELETER",
-   //      "PES_APP_ROLE",
-   //      "NEP_ROLE_VIEWER",
-   //      "SITE_ENTERPRISE_SETTING_READ",
-   //      "NEP_IDENTITY_ADMINISTRATOR",
-   //      "R1_TDM_VIEWER",
-   //      "DELIVERY_VIEWER",
-   //      "TDM_SCRUB",
-   //      "SITE_MESSAGING_SUBSCRIBE",
-   //      "SITE_UPDATE",
-   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //          "NEP_IDENTITY_VIEWER",
+   //            ... Roles List ...
+   //          "SITE_UPDATE"
    //   ],
    //   "consentScopes": [],
    //   "credentialExpired": false,

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -34,10 +34,175 @@ _This code uses Dotnet 5_
    ```console 
    $ dotnet run
    // GET Request to find sites nearby:
-   // {'sites': [], 'totalResults': 0}
+   // GET Request to view the first 10 roles in BSP:
+   //{ "status": OK }
+   //{ "Data": {
+   //    "lastPage": false,
+   //    "pageNumber": 0,
+   //    "totalPages": 190,
+   //    "totalResults": 1899,
+   //    "pageContent": [
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_LICENSE_DOWNLOAD",
+   //            "description": "User with this role is authorized to download ALX license from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
+   //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
+   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
+   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
+   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
+   //            "description": "Technical AAL Server user.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
+   //             "restrictImplies": false
+   //       }
+   //    ]
+   //  }
+   //}
    ```
 
    ```console
    $ dotnet run
-   // POST Request to find sites by criteria
+   // POST Request gain an access token
+   //{ "status": OK }
+   //{ "Data": 
+   //   {
+   //      "token": "{{YOUR_TOKEN}}}",
+   //      "maxIdleTime": 900,
+   //      "maxSessionTime": 900,
+   //      "remainingTime": 900,
+   //      "authorities": [
+   //      "NEP_IDENTITY_VIEWER",
+   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
+   //      "DELIVERY_SCRUBBER",
+   //      "R1_DC_APPLICATION_ROLE",
+   //      "R1_DC_OFFER_USER",
+   //      "R1_ORDER_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_WRITER",
+   //      "R1_ORDER_SITE_VIEWER",
+   //      "TDM_ADMIN",
+   //      "NEP_CONFIG_SETTINGS_VIEWER",
+   //      "CDM_CUSTOMER_VIEWER",
+   //      "DELIVERY_THRESHOLD_VIEWER",
+   //      "R1_CATALOG_VIEWER",
+   //      "NEP_APPLICATION_SPECTATOR",
+   //      "PES_GET",
+   //      "R1_TDM_UPLOAD",
+   //      "R1_ORDER_LOCK_ADMIN",
+   //      "SITE_READ",
+   //      "NEP_ORGANIZATION_VIEWER",
+   //      "CDM_PARTNER_CONSUMER_SEARCH",
+   //      "DYNAMIC_TYPE_VIEWER",
+   //      "R1_DC_PROVIDER",
+   //      "NEP_STORAGE_OBJECT_MODIFIER",
+   //      "R1_SUPPORT_CLIPPER",
+   //      "PES_END_OF_DAY",
+   //      "R1_CATALOG_APPLICATION",
+   //      "TDM_UPLOAD",
+   //      "R1_DC_OFFER_SUPERUSER",
+   //      "PES_ERROR",
+   //      "NEP_STORAGE_CONTAINER_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
+   //      "R1_ORDER_VIEWER",
+   //      "SITE_IMPORT",
+   //      "CDM_CUSTOMER_MODIFIER",
+   //      "R1_ORDER",
+   //      "PES_VOID",
+   //      "DELIVERY_UPDATER",
+   //      "R1_DC_APPLICATION",
+   //      "NEP_DEPLOYMENT_VIEWER",
+   //      "TDM_WRITE",
+   //      "R1_DC_POS",
+   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
+   //      "IAS_SINGLE_ITEM_VIEWER",
+   //      "IAS_MULTIPLE_ITEMS_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
+   //      "SITE_CREATE",
+   //      "R1_DC_VIEWER",
+   //      "R1_SUPPORT_USER",
+   //      "CDM_CUSTOMER_SEARCH",
+   //      "PES_FINALIZE",
+   //      "CDM_PARTNER_CONSUMER_CREATE",
+   //      "NEP_APIMANAGEMENT_VIEWER",
+   //      "OCP_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_ADMINISTRATOR",
+   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_GRANT_VIEWER",
+   //      "DELIVERY_REQUESTOR",
+   //      "NEP_JOURNALING_VIEWER",
+   //      "R1_ORDER_ADMINISTRATOR",
+   //      "CDM_ADMINISTRATOR",
+   //      "NEP_STORAGE_OBJECT_VIEWER",
+   //      "TDM_READ",
+   //      "NEP_EMAIL_SENDER",
+   //      "R1_SUPPORT_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIBER",
+   //      "R1_DC_ADMINISTRATOR",
+   //      "DX_SANDBOX",
+   //      "TDM_UPDATE",
+   //      "R1_TDM_ADMIN",
+   //      "R1_CATALOG_ADMINISTRATOR",
+   //      "NEP_JOURNALING_WRITER",
+   //      "CDM_CUSTOMER_DELETER",
+   //      "PES_APP_ROLE",
+   //      "NEP_ROLE_VIEWER",
+   //      "SITE_ENTERPRISE_SETTING_READ",
+   //      "NEP_IDENTITY_ADMINISTRATOR",
+   //      "R1_TDM_VIEWER",
+   //      "DELIVERY_VIEWER",
+   //      "TDM_SCRUB",
+   //      "SITE_MESSAGING_SUBSCRIBE",
+   //      "SITE_UPDATE",
+   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //   ],
+   //   "consentScopes": [],
+   //   "credentialExpired": false,
+   //   "organizationName": "{{YOUR_ORGANIZATION_NAME}}",
+   //   "username": "{{YOUR_ORGANIZATION}}",
+   //   "authenticationMethods": [
+   //      "access-key"
+   //   ],
+   //   "exchangesCompleted": 0,
+   //   "customClaims": [],
+   //   "singleUse": false
+   //   }
+   //}
    ```

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -33,7 +33,6 @@ _This code uses Dotnet 5_
 
    ```console 
    $ dotnet run
-   // GET Request to find sites nearby:
    // GET Request to view the first 10 roles in BSP:
    //{ "status": OK }
    //{ "Data": {

--- a/dotnet/SendGet/ContentModel.cs
+++ b/dotnet/SendGet/ContentModel.cs
@@ -1,0 +1,9 @@
+namespace SendGet{
+    public class ContentModel{
+        public bool lastPage{get; set;}
+        public int pageNumber{get; set;}
+        public int totalPages{get; set;}
+        public int totalResults{get; set;}
+        public PageContent[] pageContent{get; set;}
+    }
+}

--- a/dotnet/SendGet/PageContent.cs
+++ b/dotnet/SendGet/PageContent.cs
@@ -1,0 +1,7 @@
+namespace SendGet{
+    public class PageContent{
+        public string roleName {get; set;}
+        public string description{get; set;}
+        public bool restrictImplies{get; set;}
+    }
+}

--- a/dotnet/SendGet/Program.cs
+++ b/dotnet/SendGet/Program.cs
@@ -14,7 +14,7 @@ namespace SendGet
         */
         static void Main(string[] args)
         {
-            callGet("0434e46886a04043bdcf2af4f612ab74", "dbc6f196c2c0455594a64bf380c6f8f2", "74cb645db68647d495136bd79442239b");
+            callGet("INSERT_SECRET", "INSERT_SHARED", "INSERT_ORGANIZATION");
         }
 
         /**

--- a/dotnet/SendGet/Program.cs
+++ b/dotnet/SendGet/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using RestSharp;
 
 namespace SendGet
@@ -13,7 +14,7 @@ namespace SendGet
         */
         static void Main(string[] args)
         {
-            callGet("INSERT_SECRET","INSERT_SHARED","INSERT_ORGANIZATION");
+            callGet("0434e46886a04043bdcf2af4f612ab74", "dbc6f196c2c0455594a64bf380c6f8f2", "74cb645db68647d495136bd79442239b");
         }
 
         /**
@@ -97,7 +98,7 @@ namespace SendGet
         * @param nepOrganization A user's organization
         */
         public static void callGet(String secretKey, String sharedKey, String nepOrganization){
-            String url = "https://gateway-staging.ncrcloud.com/site/sites/find-nearby/88.05,46.25?radius=10000";
+            String url = "https://api.ncr.com/security/roles?roleNamePattern=*&pageNumber=0&pageSize=10";
             String httpMethod = "GET";
             String contentType = "application/json";
             DateTime utcDate = DateTime.UtcNow;
@@ -109,13 +110,21 @@ namespace SendGet
             var gmtDate = utcDate.DayOfWeek.ToString().Substring(0,3) + ", " + utcDate.ToString("dd MMM yyyy HH:mm:ss") + " GMT";
 
             request.AddHeader("nep-organization", nepOrganization);
-            request.AddHeader("content-type", "application/json");
+            request.AddHeader("content-type", contentType);
             request.AddHeader("date", gmtDate);
             request.AddHeader("authorization", "AccessKey " + hmacAccessKey);
 
             IRestResponse response = client.Execute(request);
 
-            Console.WriteLine("{\"status\": " + response.StatusCode + ", \"data\": " + response.Content+ "}");
+            var responseContent = JsonSerializer.Deserialize<ContentModel>(response.Content);
+            
+            var options = new JsonSerializerOptions(){
+                WriteIndented = true
+            };
+
+            var formattedJSON = JsonSerializer.Serialize(responseContent, options);    
+
+            Console.WriteLine("{ \"status\": " + response.StatusCode + " }\n{ \"Data\": \n" + formattedJSON + "\n}");
         }
     }
 }

--- a/dotnet/SendPost/ContentModel.cs
+++ b/dotnet/SendPost/ContentModel.cs
@@ -1,0 +1,17 @@
+namespace SendPost{
+    public class ContentModel{
+        public string token {get; set;}
+        public int maxIdleTime {get; set;}
+        public int maxSessionTime {get; set;}
+        public int remainingTime {get; set;}
+        public string[] authorities {get; set;}
+        public string[] consentScopes {get; set;}
+        public bool credentialExpired {get; set;}
+        public string organizationName {get; set;}
+        public string username {get; set;}
+        public string[] authenticationMethods {get; set;}
+        public int exchangesCompleted {get; set;}
+        public string[] customClaims {get; set;}
+        public bool singleUse {get; set;}
+    }
+}

--- a/dotnet/SendPost/Program.cs
+++ b/dotnet/SendPost/Program.cs
@@ -3,7 +3,6 @@ using System.Security.Cryptography;
 using System.Text;
 using RestSharp;
 using System.Text.Json;
-using SendPost;
 
 namespace SendPost
 {
@@ -15,7 +14,7 @@ namespace SendPost
         */
         static void Main(string[] args)
         {
-            callPost("0434e46886a04043bdcf2af4f612ab74", "dbc6f196c2c0455594a64bf380c6f8f2", "74cb645db68647d495136bd79442239b");
+            callPost("INSERT_SECRET", "INSERT_SHARED", "INSERT_ORGANIZATION");
         }
 
         /**

--- a/go/examples/get/main.go
+++ b/go/examples/get/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	url := "https://gateway-staging.ncrcloud.com/site/sites/find-nearby/88.05,46.25?radius=10000"
+	url := "https://api.ncr.com/security/roles?roleNamePattern=*&pageNumber=0&pageSize=10"
 	req, _ := http.NewRequest("GET", url, strings.NewReader(""))
 	req.Header.Add("Date", time.Now().UTC().Format(http.TimeFormat))
 	req.Header.Add("nep-organization", "")

--- a/go/examples/post/main.go
+++ b/go/examples/post/main.go
@@ -21,7 +21,7 @@ type siteCriteriaSort struct {
 }
 
 func main() {
-	url := "https://gateway-staging.ncrcloud.com/site/sites/find-by-criteria?pageNumber=0&pageSize=200"
+	url := "https://api.ncr.com/security/authorization"
 	criteria := &searchCriteria{
 		SortCriteria: []*siteCriteriaSort{
 			{Column: "siteName", Direction: "asc"},

--- a/java/HmacGenerator.java
+++ b/java/HmacGenerator.java
@@ -45,7 +45,12 @@ public class HmacGenerator {
         String nepServiceVersion) throws NoSuchAlgorithmException, MalformedURLException, InvalidKeyException 
     {
         URL url = new URL(requestUrl);
-        String path = url.getPath() + "?" + url.getQuery();
+
+        String path = url.getPath();
+
+        if(url.getQuery() != null && !url.getQuery().isEmpty()){
+            path += "?" + url.getQuery();
+        }
 
         String isoDate = date + ".000Z";
         

--- a/java/README.md
+++ b/java/README.md
@@ -32,11 +32,175 @@ _This code uses Java 11.0.11_
 
    ```console
    $ java SendGet
-   // GET Request to find sites nearby:
-   // {'sites': [], 'totalResults': 0}
+   // GET Request to view the first 10 roles in BSP:
+   //{ "status": OK }
+   //{ "Data": {
+   //    "lastPage": false,
+   //    "pageNumber": 0,
+   //    "totalPages": 190,
+   //    "totalResults": 1899,
+   //    "pageContent": [
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_LICENSE_DOWNLOAD",
+   //            "description": "User with this role is authorized to download ALX license from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
+   //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
+   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
+   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
+   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
+   //            "description": "Technical AAL Server user.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
+   //             "restrictImplies": false
+   //       }
+   //    ]
+   //  }
+   //}
    ```
 
    ```console
    $ java SendPost
-   // POST Request to find sites by criteria
-   ```   
+   // POST Request gain an access token
+   //{ "status": OK }
+   //{ "Data": 
+   //   {
+   //      "token": "{{YOUR_TOKEN}}}",
+   //      "maxIdleTime": 900,
+   //      "maxSessionTime": 900,
+   //      "remainingTime": 900,
+   //      "authorities": [
+   //      "NEP_IDENTITY_VIEWER",
+   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
+   //      "DELIVERY_SCRUBBER",
+   //      "R1_DC_APPLICATION_ROLE",
+   //      "R1_DC_OFFER_USER",
+   //      "R1_ORDER_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_WRITER",
+   //      "R1_ORDER_SITE_VIEWER",
+   //      "TDM_ADMIN",
+   //      "NEP_CONFIG_SETTINGS_VIEWER",
+   //      "CDM_CUSTOMER_VIEWER",
+   //      "DELIVERY_THRESHOLD_VIEWER",
+   //      "R1_CATALOG_VIEWER",
+   //      "NEP_APPLICATION_SPECTATOR",
+   //      "PES_GET",
+   //      "R1_TDM_UPLOAD",
+   //      "R1_ORDER_LOCK_ADMIN",
+   //      "SITE_READ",
+   //      "NEP_ORGANIZATION_VIEWER",
+   //      "CDM_PARTNER_CONSUMER_SEARCH",
+   //      "DYNAMIC_TYPE_VIEWER",
+   //      "R1_DC_PROVIDER",
+   //      "NEP_STORAGE_OBJECT_MODIFIER",
+   //      "R1_SUPPORT_CLIPPER",
+   //      "PES_END_OF_DAY",
+   //      "R1_CATALOG_APPLICATION",
+   //      "TDM_UPLOAD",
+   //      "R1_DC_OFFER_SUPERUSER",
+   //      "PES_ERROR",
+   //      "NEP_STORAGE_CONTAINER_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
+   //      "R1_ORDER_VIEWER",
+   //      "SITE_IMPORT",
+   //      "CDM_CUSTOMER_MODIFIER",
+   //      "R1_ORDER",
+   //      "PES_VOID",
+   //      "DELIVERY_UPDATER",
+   //      "R1_DC_APPLICATION",
+   //      "NEP_DEPLOYMENT_VIEWER",
+   //      "TDM_WRITE",
+   //      "R1_DC_POS",
+   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
+   //      "IAS_SINGLE_ITEM_VIEWER",
+   //      "IAS_MULTIPLE_ITEMS_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
+   //      "SITE_CREATE",
+   //      "R1_DC_VIEWER",
+   //      "R1_SUPPORT_USER",
+   //      "CDM_CUSTOMER_SEARCH",
+   //      "PES_FINALIZE",
+   //      "CDM_PARTNER_CONSUMER_CREATE",
+   //      "NEP_APIMANAGEMENT_VIEWER",
+   //      "OCP_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_ADMINISTRATOR",
+   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_GRANT_VIEWER",
+   //      "DELIVERY_REQUESTOR",
+   //      "NEP_JOURNALING_VIEWER",
+   //      "R1_ORDER_ADMINISTRATOR",
+   //      "CDM_ADMINISTRATOR",
+   //      "NEP_STORAGE_OBJECT_VIEWER",
+   //      "TDM_READ",
+   //      "NEP_EMAIL_SENDER",
+   //      "R1_SUPPORT_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIBER",
+   //      "R1_DC_ADMINISTRATOR",
+   //      "DX_SANDBOX",
+   //      "TDM_UPDATE",
+   //      "R1_TDM_ADMIN",
+   //      "R1_CATALOG_ADMINISTRATOR",
+   //      "NEP_JOURNALING_WRITER",
+   //      "CDM_CUSTOMER_DELETER",
+   //      "PES_APP_ROLE",
+   //      "NEP_ROLE_VIEWER",
+   //      "SITE_ENTERPRISE_SETTING_READ",
+   //      "NEP_IDENTITY_ADMINISTRATOR",
+   //      "R1_TDM_VIEWER",
+   //      "DELIVERY_VIEWER",
+   //      "TDM_SCRUB",
+   //      "SITE_MESSAGING_SUBSCRIBE",
+   //      "SITE_UPDATE",
+   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //   ],
+   //   "consentScopes": [],
+   //   "credentialExpired": false,
+   //   "organizationName": "{{YOUR_ORGANIZATION_NAME}}",
+   //   "username": "{{YOUR_ORGANIZATION}}",
+   //   "authenticationMethods": [
+   //      "access-key"
+   //   ],
+   //   "exchangesCompleted": 0,
+   //   "customClaims": [],
+   //   "singleUse": false
+   //   }
+   //}
+   ```

--- a/java/README.md
+++ b/java/README.md
@@ -39,4 +39,4 @@ _This code uses Java 11.0.11_
    ```console
    $ java SendPost
    // POST Request to find sites by criteria
-   ```
+   ```   

--- a/java/README.md
+++ b/java/README.md
@@ -49,50 +49,8 @@ _This code uses Java 11.0.11_
    //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
    //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
    //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
-   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
-   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
-   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
-   //            "description": "Technical AAL Server user.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
-   //             "restrictImplies": false
    //       }
-   //    ]
-   //  }
-   //}
+   //       ... Roles List ...
    ```
 
    ```console
@@ -106,90 +64,9 @@ _This code uses Java 11.0.11_
    //      "maxSessionTime": 900,
    //      "remainingTime": 900,
    //      "authorities": [
-   //      "NEP_IDENTITY_VIEWER",
-   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
-   //      "DELIVERY_SCRUBBER",
-   //      "R1_DC_APPLICATION_ROLE",
-   //      "R1_DC_OFFER_USER",
-   //      "R1_ORDER_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_WRITER",
-   //      "R1_ORDER_SITE_VIEWER",
-   //      "TDM_ADMIN",
-   //      "NEP_CONFIG_SETTINGS_VIEWER",
-   //      "CDM_CUSTOMER_VIEWER",
-   //      "DELIVERY_THRESHOLD_VIEWER",
-   //      "R1_CATALOG_VIEWER",
-   //      "NEP_APPLICATION_SPECTATOR",
-   //      "PES_GET",
-   //      "R1_TDM_UPLOAD",
-   //      "R1_ORDER_LOCK_ADMIN",
-   //      "SITE_READ",
-   //      "NEP_ORGANIZATION_VIEWER",
-   //      "CDM_PARTNER_CONSUMER_SEARCH",
-   //      "DYNAMIC_TYPE_VIEWER",
-   //      "R1_DC_PROVIDER",
-   //      "NEP_STORAGE_OBJECT_MODIFIER",
-   //      "R1_SUPPORT_CLIPPER",
-   //      "PES_END_OF_DAY",
-   //      "R1_CATALOG_APPLICATION",
-   //      "TDM_UPLOAD",
-   //      "R1_DC_OFFER_SUPERUSER",
-   //      "PES_ERROR",
-   //      "NEP_STORAGE_CONTAINER_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
-   //      "R1_ORDER_VIEWER",
-   //      "SITE_IMPORT",
-   //      "CDM_CUSTOMER_MODIFIER",
-   //      "R1_ORDER",
-   //      "PES_VOID",
-   //      "DELIVERY_UPDATER",
-   //      "R1_DC_APPLICATION",
-   //      "NEP_DEPLOYMENT_VIEWER",
-   //      "TDM_WRITE",
-   //      "R1_DC_POS",
-   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
-   //      "IAS_SINGLE_ITEM_VIEWER",
-   //      "IAS_MULTIPLE_ITEMS_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
-   //      "SITE_CREATE",
-   //      "R1_DC_VIEWER",
-   //      "R1_SUPPORT_USER",
-   //      "CDM_CUSTOMER_SEARCH",
-   //      "PES_FINALIZE",
-   //      "CDM_PARTNER_CONSUMER_CREATE",
-   //      "NEP_APIMANAGEMENT_VIEWER",
-   //      "OCP_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_ADMINISTRATOR",
-   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_GRANT_VIEWER",
-   //      "DELIVERY_REQUESTOR",
-   //      "NEP_JOURNALING_VIEWER",
-   //      "R1_ORDER_ADMINISTRATOR",
-   //      "CDM_ADMINISTRATOR",
-   //      "NEP_STORAGE_OBJECT_VIEWER",
-   //      "TDM_READ",
-   //      "NEP_EMAIL_SENDER",
-   //      "R1_SUPPORT_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIBER",
-   //      "R1_DC_ADMINISTRATOR",
-   //      "DX_SANDBOX",
-   //      "TDM_UPDATE",
-   //      "R1_TDM_ADMIN",
-   //      "R1_CATALOG_ADMINISTRATOR",
-   //      "NEP_JOURNALING_WRITER",
-   //      "CDM_CUSTOMER_DELETER",
-   //      "PES_APP_ROLE",
-   //      "NEP_ROLE_VIEWER",
-   //      "SITE_ENTERPRISE_SETTING_READ",
-   //      "NEP_IDENTITY_ADMINISTRATOR",
-   //      "R1_TDM_VIEWER",
-   //      "DELIVERY_VIEWER",
-   //      "TDM_SCRUB",
-   //      "SITE_MESSAGING_SUBSCRIBE",
-   //      "SITE_UPDATE",
-   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //          "NEP_IDENTITY_VIEWER",
+   //            ... Roles List ...
+   //          "SITE_UPDATE"
    //   ],
    //   "consentScopes": [],
    //   "credentialExpired": false,

--- a/java/SendPost.java
+++ b/java/SendPost.java
@@ -35,10 +35,10 @@ public class SendPost extends HmacGenerator{
      * @throws InvalidKeyException
      */
     public static void callPost(String secretKey, String sharedKey, String nepOrganization) throws NoSuchAlgorithmException, MalformedURLException, IOException, ProtocolException, InvalidKeyException{
-        String url = "https://gateway-staging.ncrcloud.com/site/sites/find-by-criteria?pageNumber=0&pageSize=10";
+        String url = "https://api.ncr.com/security/authentication/login";
         String httpMethod = "POST";
         String contentType = "application/json";
-        String dataJSON = "{\"sort\":[{\"column\":\"siteName\",\"direction\":\"asc\"}]}";
+        String dataJSON = "";
 
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
@@ -77,9 +77,73 @@ public class SendPost extends HmacGenerator{
             content.append(inputLine);
         }
  
-        System.out.println("{'status': " + status + ", 'data': " + content + "}" );
+        System.out.println("{'status': " + status + " },\n{'data': " + prettyPrintJSON(content.toString()));
  
         in.close();
         connection.disconnect();
+    }
+
+        /**
+     * A simple implementation to pretty-print JSON file.
+     *
+     * @param unformattedJsonString
+     * @return
+     */
+    public static String prettyPrintJSON(String unformattedJsonString) {
+        StringBuilder prettyJSONBuilder = new StringBuilder();
+        int indentLevel = 0;
+        boolean inQuote = false;
+        for(char charFromUnformattedJson : unformattedJsonString.toCharArray()) {
+        switch(charFromUnformattedJson) {
+            case '"':
+            // switch the quoting status
+            inQuote = !inQuote;
+            prettyJSONBuilder.append(charFromUnformattedJson);
+            break;
+            case ' ':
+            // For space: ignore the space if it is not being quoted.
+            if(inQuote) {
+                prettyJSONBuilder.append(charFromUnformattedJson);
+            }
+            break;
+            case '{':
+            case '[':
+            // Starting a new block: increase the indent level
+            prettyJSONBuilder.append(charFromUnformattedJson);
+            indentLevel++;
+            appendIndentedNewLine(indentLevel, prettyJSONBuilder);
+            break;
+            case '}':
+            case ']':
+            // Ending a new block; decrese the indent level
+            indentLevel--;
+            appendIndentedNewLine(indentLevel, prettyJSONBuilder);
+            prettyJSONBuilder.append(charFromUnformattedJson);
+            break;
+            case ',':
+            // Ending a json item; create a new line after
+            prettyJSONBuilder.append(charFromUnformattedJson);
+            if(!inQuote) {
+                appendIndentedNewLine(indentLevel, prettyJSONBuilder);
+            }
+            break;
+            default:
+            prettyJSONBuilder.append(charFromUnformattedJson);
+        }
+        }
+        return prettyJSONBuilder.toString();
+    }
+    
+    /**
+     * Print a new line with indention at the beginning of the new line.
+     * @param indentLevel
+     * @param stringBuilder
+     */
+    private static void appendIndentedNewLine(int indentLevel, StringBuilder stringBuilder) {
+        stringBuilder.append("\n");
+        for(int i = 0; i < indentLevel; i++) {
+        // Assuming indention using 2 spaces
+        stringBuilder.append("  ");
+        }
     }
 }

--- a/js/README.md
+++ b/js/README.md
@@ -34,50 +34,9 @@ The example helper function lives in `hmac.js` which containst the details on ho
    //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
    //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
    //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
-   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
-   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
-   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
-   //            "description": "Technical AAL Server user.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
-   //             "restrictImplies": false
    //       }
-   //    ]
-   //  }
-   //}
+   //       ... Roles List ...
+   ```
 
    // POST Request gain an access token
    //{ "status": OK }
@@ -88,90 +47,9 @@ The example helper function lives in `hmac.js` which containst the details on ho
    //      "maxSessionTime": 900,
    //      "remainingTime": 900,
    //      "authorities": [
-   //      "NEP_IDENTITY_VIEWER",
-   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
-   //      "DELIVERY_SCRUBBER",
-   //      "R1_DC_APPLICATION_ROLE",
-   //      "R1_DC_OFFER_USER",
-   //      "R1_ORDER_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_WRITER",
-   //      "R1_ORDER_SITE_VIEWER",
-   //      "TDM_ADMIN",
-   //      "NEP_CONFIG_SETTINGS_VIEWER",
-   //      "CDM_CUSTOMER_VIEWER",
-   //      "DELIVERY_THRESHOLD_VIEWER",
-   //      "R1_CATALOG_VIEWER",
-   //      "NEP_APPLICATION_SPECTATOR",
-   //      "PES_GET",
-   //      "R1_TDM_UPLOAD",
-   //      "R1_ORDER_LOCK_ADMIN",
-   //      "SITE_READ",
-   //      "NEP_ORGANIZATION_VIEWER",
-   //      "CDM_PARTNER_CONSUMER_SEARCH",
-   //      "DYNAMIC_TYPE_VIEWER",
-   //      "R1_DC_PROVIDER",
-   //      "NEP_STORAGE_OBJECT_MODIFIER",
-   //      "R1_SUPPORT_CLIPPER",
-   //      "PES_END_OF_DAY",
-   //      "R1_CATALOG_APPLICATION",
-   //      "TDM_UPLOAD",
-   //      "R1_DC_OFFER_SUPERUSER",
-   //      "PES_ERROR",
-   //      "NEP_STORAGE_CONTAINER_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
-   //      "R1_ORDER_VIEWER",
-   //      "SITE_IMPORT",
-   //      "CDM_CUSTOMER_MODIFIER",
-   //      "R1_ORDER",
-   //      "PES_VOID",
-   //      "DELIVERY_UPDATER",
-   //      "R1_DC_APPLICATION",
-   //      "NEP_DEPLOYMENT_VIEWER",
-   //      "TDM_WRITE",
-   //      "R1_DC_POS",
-   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
-   //      "IAS_SINGLE_ITEM_VIEWER",
-   //      "IAS_MULTIPLE_ITEMS_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
-   //      "SITE_CREATE",
-   //      "R1_DC_VIEWER",
-   //      "R1_SUPPORT_USER",
-   //      "CDM_CUSTOMER_SEARCH",
-   //      "PES_FINALIZE",
-   //      "CDM_PARTNER_CONSUMER_CREATE",
-   //      "NEP_APIMANAGEMENT_VIEWER",
-   //      "OCP_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_ADMINISTRATOR",
-   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_GRANT_VIEWER",
-   //      "DELIVERY_REQUESTOR",
-   //      "NEP_JOURNALING_VIEWER",
-   //      "R1_ORDER_ADMINISTRATOR",
-   //      "CDM_ADMINISTRATOR",
-   //      "NEP_STORAGE_OBJECT_VIEWER",
-   //      "TDM_READ",
-   //      "NEP_EMAIL_SENDER",
-   //      "R1_SUPPORT_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIBER",
-   //      "R1_DC_ADMINISTRATOR",
-   //      "DX_SANDBOX",
-   //      "TDM_UPDATE",
-   //      "R1_TDM_ADMIN",
-   //      "R1_CATALOG_ADMINISTRATOR",
-   //      "NEP_JOURNALING_WRITER",
-   //      "CDM_CUSTOMER_DELETER",
-   //      "PES_APP_ROLE",
-   //      "NEP_ROLE_VIEWER",
-   //      "SITE_ENTERPRISE_SETTING_READ",
-   //      "NEP_IDENTITY_ADMINISTRATOR",
-   //      "R1_TDM_VIEWER",
-   //      "DELIVERY_VIEWER",
-   //      "TDM_SCRUB",
-   //      "SITE_MESSAGING_SUBSCRIBE",
-   //      "SITE_UPDATE",
-   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //          "NEP_IDENTITY_VIEWER",
+   //            ... Roles List ...
+   //          "SITE_UPDATE"
    //   ],
    //   "consentScopes": [],
    //   "credentialExpired": false,

--- a/js/README.md
+++ b/js/README.md
@@ -17,7 +17,172 @@ The example helper function lives in `hmac.js` which containst the details on ho
 
    ```console
    $ node index.js
-   // GET Request to find sites nearby:
-   // {status: 200, data: {'sites': [], 'totalResults': 0}}
-   // ...
+   // GET Request to view the first 10 roles in BSP:
+   //{ "status": OK }
+   //{ "Data": {
+   //    "lastPage": false,
+   //    "pageNumber": 0,
+   //    "totalPages": 190,
+   //    "totalResults": 1899,
+   //    "pageContent": [
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_LICENSE_DOWNLOAD",
+   //            "description": "User with this role is authorized to download ALX license from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
+   //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
+   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
+   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
+   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
+   //            "description": "Technical AAL Server user.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
+   //             "restrictImplies": false
+   //       }
+   //    ]
+   //  }
+   //}
+
+   // POST Request gain an access token
+   //{ "status": OK }
+   //{ "Data": 
+   //   {
+   //      "token": "{{YOUR_TOKEN}}}",
+   //      "maxIdleTime": 900,
+   //      "maxSessionTime": 900,
+   //      "remainingTime": 900,
+   //      "authorities": [
+   //      "NEP_IDENTITY_VIEWER",
+   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
+   //      "DELIVERY_SCRUBBER",
+   //      "R1_DC_APPLICATION_ROLE",
+   //      "R1_DC_OFFER_USER",
+   //      "R1_ORDER_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_WRITER",
+   //      "R1_ORDER_SITE_VIEWER",
+   //      "TDM_ADMIN",
+   //      "NEP_CONFIG_SETTINGS_VIEWER",
+   //      "CDM_CUSTOMER_VIEWER",
+   //      "DELIVERY_THRESHOLD_VIEWER",
+   //      "R1_CATALOG_VIEWER",
+   //      "NEP_APPLICATION_SPECTATOR",
+   //      "PES_GET",
+   //      "R1_TDM_UPLOAD",
+   //      "R1_ORDER_LOCK_ADMIN",
+   //      "SITE_READ",
+   //      "NEP_ORGANIZATION_VIEWER",
+   //      "CDM_PARTNER_CONSUMER_SEARCH",
+   //      "DYNAMIC_TYPE_VIEWER",
+   //      "R1_DC_PROVIDER",
+   //      "NEP_STORAGE_OBJECT_MODIFIER",
+   //      "R1_SUPPORT_CLIPPER",
+   //      "PES_END_OF_DAY",
+   //      "R1_CATALOG_APPLICATION",
+   //      "TDM_UPLOAD",
+   //      "R1_DC_OFFER_SUPERUSER",
+   //      "PES_ERROR",
+   //      "NEP_STORAGE_CONTAINER_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
+   //      "R1_ORDER_VIEWER",
+   //      "SITE_IMPORT",
+   //      "CDM_CUSTOMER_MODIFIER",
+   //      "R1_ORDER",
+   //      "PES_VOID",
+   //      "DELIVERY_UPDATER",
+   //      "R1_DC_APPLICATION",
+   //      "NEP_DEPLOYMENT_VIEWER",
+   //      "TDM_WRITE",
+   //      "R1_DC_POS",
+   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
+   //      "IAS_SINGLE_ITEM_VIEWER",
+   //      "IAS_MULTIPLE_ITEMS_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
+   //      "SITE_CREATE",
+   //      "R1_DC_VIEWER",
+   //      "R1_SUPPORT_USER",
+   //      "CDM_CUSTOMER_SEARCH",
+   //      "PES_FINALIZE",
+   //      "CDM_PARTNER_CONSUMER_CREATE",
+   //      "NEP_APIMANAGEMENT_VIEWER",
+   //      "OCP_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_ADMINISTRATOR",
+   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_GRANT_VIEWER",
+   //      "DELIVERY_REQUESTOR",
+   //      "NEP_JOURNALING_VIEWER",
+   //      "R1_ORDER_ADMINISTRATOR",
+   //      "CDM_ADMINISTRATOR",
+   //      "NEP_STORAGE_OBJECT_VIEWER",
+   //      "TDM_READ",
+   //      "NEP_EMAIL_SENDER",
+   //      "R1_SUPPORT_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIBER",
+   //      "R1_DC_ADMINISTRATOR",
+   //      "DX_SANDBOX",
+   //      "TDM_UPDATE",
+   //      "R1_TDM_ADMIN",
+   //      "R1_CATALOG_ADMINISTRATOR",
+   //      "NEP_JOURNALING_WRITER",
+   //      "CDM_CUSTOMER_DELETER",
+   //      "PES_APP_ROLE",
+   //      "NEP_ROLE_VIEWER",
+   //      "SITE_ENTERPRISE_SETTING_READ",
+   //      "NEP_IDENTITY_ADMINISTRATOR",
+   //      "R1_TDM_VIEWER",
+   //      "DELIVERY_VIEWER",
+   //      "TDM_SCRUB",
+   //      "SITE_MESSAGING_SUBSCRIBE",
+   //      "SITE_UPDATE",
+   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //   ],
+   //   "consentScopes": [],
+   //   "credentialExpired": false,
+   //   "organizationName": "{{YOUR_ORGANIZATION_NAME}}",
+   //   "username": "{{YOUR_ORGANIZATION}}",
+   //   "authenticationMethods": [
+   //      "access-key"
+   //   ],
+   //   "exchangesCompleted": 0,
+   //   "customClaims": [],
+   //   "singleUse": false
+   //   }
+   //}
    ```

--- a/js/example-get.js
+++ b/js/example-get.js
@@ -10,7 +10,7 @@ async function exampleGet(secretKey, sharedKey, nepOrganization) {
     sharedKey,
     nepOrganization,
     requestURL:
-      "https://gateway-staging.ncrcloud.com/site/sites/find-nearby/88.05,46.25?radius=10000",
+      "https://api.ncr.com/security/roles?roleNamePattern=*&pageNumber=0&pageSize=10",
     httpMethod: "GET",
     contentType: "application/json",
   };

--- a/js/example-post.js
+++ b/js/example-post.js
@@ -11,7 +11,7 @@ async function examplePost(secretKey, sharedKey, nepOrganization) {
     sharedKey,
     nepOrganization,
     requestURL:
-      "https://gateway-staging.ncrcloud.com/site/sites/find-by-criteria?pageNumber=0&pageSize=200",
+      "https://api.ncr.com/security/authorization",
     httpMethod: "POST",
     contentType: "application/json",
   };

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -16,12 +16,176 @@ The example helper function lives in `hmac.psm1` which contains the HMAC `Access
 
    ```console
    PS C:\ncr-bsp-hmac\powershell> .\example-get.ps1
-
-   // {'sites': [], 'totalResults': 0}
+   // GET Request to view the first 10 roles in BSP:
+   //{ "status": OK }
+   //{ "Data": {
+   //    "lastPage": false,
+   //    "pageNumber": 0,
+   //    "totalPages": 190,
+   //    "totalResults": 1899,
+   //    "pageContent": [
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_LICENSE_DOWNLOAD",
+   //            "description": "User with this role is authorized to download ALX license from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
+   //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
+   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
+   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
+   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
+   //            "description": "Technical AAL Server user.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
+   //             "restrictImplies": false
+   //       }
+   //    ]
+   //  }
+   //}
    ```
 
    ```console
    PS C:\ncr-bsp-hmac\powershell> .\example-post.ps1
 
-   // {"lastPage":true,"pageNumber":0,"totalPages":0,"totalResults":0,"pageContent":[]}
+   // POST Request gain an access token
+   //{ "status": OK }
+   //{ "Data": 
+   //   {
+   //      "token": "{{YOUR_TOKEN}}}",
+   //      "maxIdleTime": 900,
+   //      "maxSessionTime": 900,
+   //      "remainingTime": 900,
+   //      "authorities": [
+   //      "NEP_IDENTITY_VIEWER",
+   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
+   //      "DELIVERY_SCRUBBER",
+   //      "R1_DC_APPLICATION_ROLE",
+   //      "R1_DC_OFFER_USER",
+   //      "R1_ORDER_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_WRITER",
+   //      "R1_ORDER_SITE_VIEWER",
+   //      "TDM_ADMIN",
+   //      "NEP_CONFIG_SETTINGS_VIEWER",
+   //      "CDM_CUSTOMER_VIEWER",
+   //      "DELIVERY_THRESHOLD_VIEWER",
+   //      "R1_CATALOG_VIEWER",
+   //      "NEP_APPLICATION_SPECTATOR",
+   //      "PES_GET",
+   //      "R1_TDM_UPLOAD",
+   //      "R1_ORDER_LOCK_ADMIN",
+   //      "SITE_READ",
+   //      "NEP_ORGANIZATION_VIEWER",
+   //      "CDM_PARTNER_CONSUMER_SEARCH",
+   //      "DYNAMIC_TYPE_VIEWER",
+   //      "R1_DC_PROVIDER",
+   //      "NEP_STORAGE_OBJECT_MODIFIER",
+   //      "R1_SUPPORT_CLIPPER",
+   //      "PES_END_OF_DAY",
+   //      "R1_CATALOG_APPLICATION",
+   //      "TDM_UPLOAD",
+   //      "R1_DC_OFFER_SUPERUSER",
+   //      "PES_ERROR",
+   //      "NEP_STORAGE_CONTAINER_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
+   //      "R1_ORDER_VIEWER",
+   //      "SITE_IMPORT",
+   //      "CDM_CUSTOMER_MODIFIER",
+   //      "R1_ORDER",
+   //      "PES_VOID",
+   //      "DELIVERY_UPDATER",
+   //      "R1_DC_APPLICATION",
+   //      "NEP_DEPLOYMENT_VIEWER",
+   //      "TDM_WRITE",
+   //      "R1_DC_POS",
+   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
+   //      "IAS_SINGLE_ITEM_VIEWER",
+   //      "IAS_MULTIPLE_ITEMS_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
+   //      "SITE_CREATE",
+   //      "R1_DC_VIEWER",
+   //      "R1_SUPPORT_USER",
+   //      "CDM_CUSTOMER_SEARCH",
+   //      "PES_FINALIZE",
+   //      "CDM_PARTNER_CONSUMER_CREATE",
+   //      "NEP_APIMANAGEMENT_VIEWER",
+   //      "OCP_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_ADMINISTRATOR",
+   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_GRANT_VIEWER",
+   //      "DELIVERY_REQUESTOR",
+   //      "NEP_JOURNALING_VIEWER",
+   //      "R1_ORDER_ADMINISTRATOR",
+   //      "CDM_ADMINISTRATOR",
+   //      "NEP_STORAGE_OBJECT_VIEWER",
+   //      "TDM_READ",
+   //      "NEP_EMAIL_SENDER",
+   //      "R1_SUPPORT_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIBER",
+   //      "R1_DC_ADMINISTRATOR",
+   //      "DX_SANDBOX",
+   //      "TDM_UPDATE",
+   //      "R1_TDM_ADMIN",
+   //      "R1_CATALOG_ADMINISTRATOR",
+   //      "NEP_JOURNALING_WRITER",
+   //      "CDM_CUSTOMER_DELETER",
+   //      "PES_APP_ROLE",
+   //      "NEP_ROLE_VIEWER",
+   //      "SITE_ENTERPRISE_SETTING_READ",
+   //      "NEP_IDENTITY_ADMINISTRATOR",
+   //      "R1_TDM_VIEWER",
+   //      "DELIVERY_VIEWER",
+   //      "TDM_SCRUB",
+   //      "SITE_MESSAGING_SUBSCRIBE",
+   //      "SITE_UPDATE",
+   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //   ],
+   //   "consentScopes": [],
+   //   "credentialExpired": false,
+   //   "organizationName": "{{YOUR_ORGANIZATION_NAME}}",
+   //   "username": "{{YOUR_ORGANIZATION}}",
+   //   "authenticationMethods": [
+   //      "access-key"
+   //   ],
+   //   "exchangesCompleted": 0,
+   //   "customClaims": [],
+   //   "singleUse": false
+   //   }
+   //}
    ```

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -33,50 +33,8 @@ The example helper function lives in `hmac.psm1` which contains the HMAC `Access
    //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
    //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
    //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
-   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
-   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
-   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
-   //            "description": "Technical AAL Server user.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
-   //             "restrictImplies": false
    //       }
-   //    ]
-   //  }
-   //}
+   //       ... Roles List ...
    ```
 
    ```console
@@ -91,90 +49,9 @@ The example helper function lives in `hmac.psm1` which contains the HMAC `Access
    //      "maxSessionTime": 900,
    //      "remainingTime": 900,
    //      "authorities": [
-   //      "NEP_IDENTITY_VIEWER",
-   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
-   //      "DELIVERY_SCRUBBER",
-   //      "R1_DC_APPLICATION_ROLE",
-   //      "R1_DC_OFFER_USER",
-   //      "R1_ORDER_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_WRITER",
-   //      "R1_ORDER_SITE_VIEWER",
-   //      "TDM_ADMIN",
-   //      "NEP_CONFIG_SETTINGS_VIEWER",
-   //      "CDM_CUSTOMER_VIEWER",
-   //      "DELIVERY_THRESHOLD_VIEWER",
-   //      "R1_CATALOG_VIEWER",
-   //      "NEP_APPLICATION_SPECTATOR",
-   //      "PES_GET",
-   //      "R1_TDM_UPLOAD",
-   //      "R1_ORDER_LOCK_ADMIN",
-   //      "SITE_READ",
-   //      "NEP_ORGANIZATION_VIEWER",
-   //      "CDM_PARTNER_CONSUMER_SEARCH",
-   //      "DYNAMIC_TYPE_VIEWER",
-   //      "R1_DC_PROVIDER",
-   //      "NEP_STORAGE_OBJECT_MODIFIER",
-   //      "R1_SUPPORT_CLIPPER",
-   //      "PES_END_OF_DAY",
-   //      "R1_CATALOG_APPLICATION",
-   //      "TDM_UPLOAD",
-   //      "R1_DC_OFFER_SUPERUSER",
-   //      "PES_ERROR",
-   //      "NEP_STORAGE_CONTAINER_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
-   //      "R1_ORDER_VIEWER",
-   //      "SITE_IMPORT",
-   //      "CDM_CUSTOMER_MODIFIER",
-   //      "R1_ORDER",
-   //      "PES_VOID",
-   //      "DELIVERY_UPDATER",
-   //      "R1_DC_APPLICATION",
-   //      "NEP_DEPLOYMENT_VIEWER",
-   //      "TDM_WRITE",
-   //      "R1_DC_POS",
-   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
-   //      "IAS_SINGLE_ITEM_VIEWER",
-   //      "IAS_MULTIPLE_ITEMS_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
-   //      "SITE_CREATE",
-   //      "R1_DC_VIEWER",
-   //      "R1_SUPPORT_USER",
-   //      "CDM_CUSTOMER_SEARCH",
-   //      "PES_FINALIZE",
-   //      "CDM_PARTNER_CONSUMER_CREATE",
-   //      "NEP_APIMANAGEMENT_VIEWER",
-   //      "OCP_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_ADMINISTRATOR",
-   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_GRANT_VIEWER",
-   //      "DELIVERY_REQUESTOR",
-   //      "NEP_JOURNALING_VIEWER",
-   //      "R1_ORDER_ADMINISTRATOR",
-   //      "CDM_ADMINISTRATOR",
-   //      "NEP_STORAGE_OBJECT_VIEWER",
-   //      "TDM_READ",
-   //      "NEP_EMAIL_SENDER",
-   //      "R1_SUPPORT_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIBER",
-   //      "R1_DC_ADMINISTRATOR",
-   //      "DX_SANDBOX",
-   //      "TDM_UPDATE",
-   //      "R1_TDM_ADMIN",
-   //      "R1_CATALOG_ADMINISTRATOR",
-   //      "NEP_JOURNALING_WRITER",
-   //      "CDM_CUSTOMER_DELETER",
-   //      "PES_APP_ROLE",
-   //      "NEP_ROLE_VIEWER",
-   //      "SITE_ENTERPRISE_SETTING_READ",
-   //      "NEP_IDENTITY_ADMINISTRATOR",
-   //      "R1_TDM_VIEWER",
-   //      "DELIVERY_VIEWER",
-   //      "TDM_SCRUB",
-   //      "SITE_MESSAGING_SUBSCRIBE",
-   //      "SITE_UPDATE",
-   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //          "NEP_IDENTITY_VIEWER",
+   //            ... Roles List ...
+   //          "SITE_UPDATE"
    //   ],
    //   "consentScopes": [],
    //   "credentialExpired": false,
@@ -189,3 +66,4 @@ The example helper function lives in `hmac.psm1` which contains the HMAC `Access
    //   }
    //}
    ```
+

--- a/powershell/example-get.ps1
+++ b/powershell/example-get.ps1
@@ -4,7 +4,7 @@ $sharedKey = "INSERT SHARED KEY"
 $secretKey = "INSERT SECRET KEY"
 $organization = "INSERT ORGANIZATION"
 
-$url = "https://api.ncr.com/site/sites/find-nearby/88.05,46.25?radius=10000"
+$url = "https://api.ncr.com/security/roles?roleNamePattern=*&pageNumber=0&pageSize=10"
 $now = Get-Date
 
 $accessKey = Get-AccessKey -sharedKey $sharedKey `

--- a/powershell/example-post.ps1
+++ b/powershell/example-post.ps1
@@ -4,7 +4,7 @@ $sharedKey = "INSERT SHARED KEY"
 $secretKey = "INSERT SECRET KEY"
 $organization = "INSERT ORGANIZATION"
 
-$url = "https://api.ncr.com/site/sites/find-by-criteria?pageNumber=0&pageSize=10"
+$url = "https://api.ncr.com/security/authorization"
 $now = Get-Date
 
 $accessKey = Get-AccessKey -sharedKey $sharedKey `

--- a/python/README.md
+++ b/python/README.md
@@ -36,50 +36,8 @@ _This code uses Python 3_
    //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
    //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
    //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
-   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
-   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
-   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
-   //            "description": "Technical AAL Server user.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
-   //            "restrictImplies": false
-   //       },
-   //       {
-   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
-   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
-   //             "restrictImplies": false
    //       }
-   //    ]
-   //  }
-   //}
+   //       ... Roles List ...
    ```
 
    ```console
@@ -93,90 +51,9 @@ _This code uses Python 3_
    //      "maxSessionTime": 900,
    //      "remainingTime": 900,
    //      "authorities": [
-   //      "NEP_IDENTITY_VIEWER",
-   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
-   //      "DELIVERY_SCRUBBER",
-   //      "R1_DC_APPLICATION_ROLE",
-   //      "R1_DC_OFFER_USER",
-   //      "R1_ORDER_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_WRITER",
-   //      "R1_ORDER_SITE_VIEWER",
-   //      "TDM_ADMIN",
-   //      "NEP_CONFIG_SETTINGS_VIEWER",
-   //      "CDM_CUSTOMER_VIEWER",
-   //      "DELIVERY_THRESHOLD_VIEWER",
-   //      "R1_CATALOG_VIEWER",
-   //      "NEP_APPLICATION_SPECTATOR",
-   //      "PES_GET",
-   //      "R1_TDM_UPLOAD",
-   //      "R1_ORDER_LOCK_ADMIN",
-   //      "SITE_READ",
-   //      "NEP_ORGANIZATION_VIEWER",
-   //      "CDM_PARTNER_CONSUMER_SEARCH",
-   //      "DYNAMIC_TYPE_VIEWER",
-   //      "R1_DC_PROVIDER",
-   //      "NEP_STORAGE_OBJECT_MODIFIER",
-   //      "R1_SUPPORT_CLIPPER",
-   //      "PES_END_OF_DAY",
-   //      "R1_CATALOG_APPLICATION",
-   //      "TDM_UPLOAD",
-   //      "R1_DC_OFFER_SUPERUSER",
-   //      "PES_ERROR",
-   //      "NEP_STORAGE_CONTAINER_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
-   //      "R1_ORDER_VIEWER",
-   //      "SITE_IMPORT",
-   //      "CDM_CUSTOMER_MODIFIER",
-   //      "R1_ORDER",
-   //      "PES_VOID",
-   //      "DELIVERY_UPDATER",
-   //      "R1_DC_APPLICATION",
-   //      "NEP_DEPLOYMENT_VIEWER",
-   //      "TDM_WRITE",
-   //      "R1_DC_POS",
-   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
-   //      "IAS_SINGLE_ITEM_VIEWER",
-   //      "IAS_MULTIPLE_ITEMS_VIEWER",
-   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
-   //      "SITE_CREATE",
-   //      "R1_DC_VIEWER",
-   //      "R1_SUPPORT_USER",
-   //      "CDM_CUSTOMER_SEARCH",
-   //      "PES_FINALIZE",
-   //      "CDM_PARTNER_CONSUMER_CREATE",
-   //      "NEP_APIMANAGEMENT_VIEWER",
-   //      "OCP_SITE_ADMINISTRATOR",
-   //      "DYNAMIC_TYPE_ADMINISTRATOR",
-   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_GRANT_VIEWER",
-   //      "DELIVERY_REQUESTOR",
-   //      "NEP_JOURNALING_VIEWER",
-   //      "R1_ORDER_ADMINISTRATOR",
-   //      "CDM_ADMINISTRATOR",
-   //      "NEP_STORAGE_OBJECT_VIEWER",
-   //      "TDM_READ",
-   //      "NEP_EMAIL_SENDER",
-   //      "R1_SUPPORT_ADMINISTRATOR",
-   //      "NEP_ENTERPRISE_VIEWER",
-   //      "NEP_MESSAGING_SUBSCRIBER",
-   //      "R1_DC_ADMINISTRATOR",
-   //      "DX_SANDBOX",
-   //      "TDM_UPDATE",
-   //      "R1_TDM_ADMIN",
-   //      "R1_CATALOG_ADMINISTRATOR",
-   //      "NEP_JOURNALING_WRITER",
-   //      "CDM_CUSTOMER_DELETER",
-   //      "PES_APP_ROLE",
-   //      "NEP_ROLE_VIEWER",
-   //      "SITE_ENTERPRISE_SETTING_READ",
-   //      "NEP_IDENTITY_ADMINISTRATOR",
-   //      "R1_TDM_VIEWER",
-   //      "DELIVERY_VIEWER",
-   //      "TDM_SCRUB",
-   //      "SITE_MESSAGING_SUBSCRIBE",
-   //      "SITE_UPDATE",
-   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //          "NEP_IDENTITY_VIEWER",
+   //            ... Roles List ...
+   //          "SITE_UPDATE"
    //   ],
    //   "consentScopes": [],
    //   "credentialExpired": false,

--- a/python/README.md
+++ b/python/README.md
@@ -19,11 +19,175 @@ _This code uses Python 3_
 
    ```console
    $ python3 exampleGet.py
-   // GET Request to find sites nearby:
-   // {'sites': [], 'totalResults': 0}
+   // GET Request to view the first 10 roles in BSP:
+   //{ "status": OK }
+   //{ "Data": {
+   //    "lastPage": false,
+   //    "pageNumber": 0,
+   //    "totalPages": 190,
+   //    "totalResults": 1899,
+   //    "pageContent": [
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_LICENSE_DOWNLOAD",
+   //            "description": "User with this role is authorized to download ALX license from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_MANIFEST_VIEWER",
+   //            "description": "User with this role is authorized to see site manifest for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_SOLUTION_SET_RESOLVER_VIEWER",
+   //            "description": "User with this role is authorized to see solution set resolution for an enterprise unit.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and delete installation tokens within the given organization.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SITE_STAGING_VIEWER",
+   //            "description": "User with this role is authorized retrieve the configuration data related to site staging.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_SOLUTION_SET_VIEWER",
+   //            "description": "User with this role is authorized to view solution sets from AAL Server API.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER",
+   //            "description": "Technical AAL Server user.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_TECHNICAL_USER_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to create and retrieve credentials of site-level technical users.",
+   //            "restrictImplies": false
+   //       },
+   //       {
+   //            "roleName": "ALOHA_AAL_SERVER_UPGRADE_POOL_ADMINISTRATOR",
+   //            "description": "User with this role is authorized to administrate upgrade pools from AAL Server API.",
+   //             "restrictImplies": false
+   //       }
+   //    ]
+   //  }
+   //}
    ```
 
    ```console
    $ python3 examplePost.py
-   // POST Request to find sites by criteria
+   // POST Request gain an access token
+   //{ "status": OK }
+   //{ "Data": 
+   //   {
+   //      "token": "{{YOUR_TOKEN}}}",
+   //      "maxIdleTime": 900,
+   //      "maxSessionTime": 900,
+   //      "remainingTime": 900,
+   //      "authorities": [
+   //      "NEP_IDENTITY_VIEWER",
+   //      "NEP_CONFIG_SETTINGS_ADMINISTRATOR",
+   //      "DELIVERY_SCRUBBER",
+   //      "R1_DC_APPLICATION_ROLE",
+   //      "R1_DC_OFFER_USER",
+   //      "R1_ORDER_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_WRITER",
+   //      "R1_ORDER_SITE_VIEWER",
+   //      "TDM_ADMIN",
+   //      "NEP_CONFIG_SETTINGS_VIEWER",
+   //      "CDM_CUSTOMER_VIEWER",
+   //      "DELIVERY_THRESHOLD_VIEWER",
+   //      "R1_CATALOG_VIEWER",
+   //      "NEP_APPLICATION_SPECTATOR",
+   //      "PES_GET",
+   //      "R1_TDM_UPLOAD",
+   //      "R1_ORDER_LOCK_ADMIN",
+   //      "SITE_READ",
+   //      "NEP_ORGANIZATION_VIEWER",
+   //      "CDM_PARTNER_CONSUMER_SEARCH",
+   //      "DYNAMIC_TYPE_VIEWER",
+   //      "R1_DC_PROVIDER",
+   //      "NEP_STORAGE_OBJECT_MODIFIER",
+   //      "R1_SUPPORT_CLIPPER",
+   //      "PES_END_OF_DAY",
+   //      "R1_CATALOG_APPLICATION",
+   //      "TDM_UPLOAD",
+   //      "R1_DC_OFFER_SUPERUSER",
+   //      "PES_ERROR",
+   //      "NEP_STORAGE_CONTAINER_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIPTION_VIEWER",
+   //      "R1_ORDER_VIEWER",
+   //      "SITE_IMPORT",
+   //      "CDM_CUSTOMER_MODIFIER",
+   //      "R1_ORDER",
+   //      "PES_VOID",
+   //      "DELIVERY_UPDATER",
+   //      "R1_DC_APPLICATION",
+   //      "NEP_DEPLOYMENT_VIEWER",
+   //      "TDM_WRITE",
+   //      "R1_DC_POS",
+   //      "NEP_STORAGE_CONTAINER_ADMINISTRATOR",
+   //      "IAS_SINGLE_ITEM_VIEWER",
+   //      "IAS_MULTIPLE_ITEMS_VIEWER",
+   //      "NEP_ENTERPRISE_SUPER_ADMINISTRATOR",
+   //      "SITE_CREATE",
+   //      "R1_DC_VIEWER",
+   //      "R1_SUPPORT_USER",
+   //      "CDM_CUSTOMER_SEARCH",
+   //      "PES_FINALIZE",
+   //      "CDM_PARTNER_CONSUMER_CREATE",
+   //      "NEP_APIMANAGEMENT_VIEWER",
+   //      "OCP_SITE_ADMINISTRATOR",
+   //      "DYNAMIC_TYPE_ADMINISTRATOR",
+   //      "IAS_MULTIPLE_ITEMS_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_GRANT_VIEWER",
+   //      "DELIVERY_REQUESTOR",
+   //      "NEP_JOURNALING_VIEWER",
+   //      "R1_ORDER_ADMINISTRATOR",
+   //      "CDM_ADMINISTRATOR",
+   //      "NEP_STORAGE_OBJECT_VIEWER",
+   //      "TDM_READ",
+   //      "NEP_EMAIL_SENDER",
+   //      "R1_SUPPORT_ADMINISTRATOR",
+   //      "NEP_ENTERPRISE_VIEWER",
+   //      "NEP_MESSAGING_SUBSCRIBER",
+   //      "R1_DC_ADMINISTRATOR",
+   //      "DX_SANDBOX",
+   //      "TDM_UPDATE",
+   //      "R1_TDM_ADMIN",
+   //      "R1_CATALOG_ADMINISTRATOR",
+   //      "NEP_JOURNALING_WRITER",
+   //      "CDM_CUSTOMER_DELETER",
+   //      "PES_APP_ROLE",
+   //      "NEP_ROLE_VIEWER",
+   //      "SITE_ENTERPRISE_SETTING_READ",
+   //      "NEP_IDENTITY_ADMINISTRATOR",
+   //      "R1_TDM_VIEWER",
+   //      "DELIVERY_VIEWER",
+   //      "TDM_SCRUB",
+   //      "SITE_MESSAGING_SUBSCRIBE",
+   //      "SITE_UPDATE",
+   //      "IAS_SINGLE_ITEM_ADMINISTRATOR"
+   //   ],
+   //   "consentScopes": [],
+   //   "credentialExpired": false,
+   //   "organizationName": "{{YOUR_ORGANIZATION_NAME}}",
+   //   "username": "{{YOUR_ORGANIZATION}}",
+   //   "authenticationMethods": [
+   //      "access-key"
+   //   ],
+   //   "exchangesCompleted": 0,
+   //   "customClaims": [],
+   //   "singleUse": false
+   //   }
+   //}
    ```

--- a/python/exampleGet.py
+++ b/python/exampleGet.py
@@ -1,16 +1,17 @@
 from hmacHelper import hmacHelper
 from datetime import datetime
 from datetime import timezone
+import json
 import requests
 
 
 def exampleGet(secretKey="INSERT_SECRET", sharedKey="INSERT_SHARED", nepOrganization="INSERT_ORGANIZATION"):
-
+    
     now = datetime.now(tz=timezone.utc)
     now = datetime(now.year, now.month, now.day, hour=now.hour,
                    minute=now.minute, second=now.second)
 
-    requestURL = "https://gateway-staging.ncrcloud.com/site/sites/find-nearby/88.05,46.25?radius=10000"
+    requestURL = "https://api.ncr.com/security/roles?roleNamePattern=*&pageNumber=0&pageSize=10"
     httpMethod = 'GET'
     contentType = 'application/json'
 
@@ -31,7 +32,8 @@ def exampleGet(secretKey="INSERT_SECRET", sharedKey="INSERT_SHARED", nepOrganiza
     res['status'] = request.status_code
     res['data'] = request.json()
 
-    print(res)
+    json_formatted = json.dumps(res, indent=2)
+    print(json_formatted)
 
     return res
 

--- a/python/examplePost.py
+++ b/python/examplePost.py
@@ -6,12 +6,12 @@ import json
 
 
 def examplePost(secretKey="INSERT_SECRET", sharedKey="INSERT_SHARED", nepOrganization="INSERT_ORGANIZATION"):
-
+    
     now = datetime.now(tz=timezone.utc)
     now = datetime(now.year, now.month, now.day, hour=now.hour,
                    minute=now.minute, second=now.second)
 
-    requestURL = "https://gateway-staging.ncrcloud.com/site/sites/find-by-criteria?pageNumber=0&pageSize=10"
+    requestURL = "https://api.ncr.com/security/authentication/login"
     httpMethod = 'POST'
     contentType = 'application/json'
 
@@ -27,7 +27,6 @@ def examplePost(secretKey="INSERT_SECRET", sharedKey="INSERT_SHARED", nepOrganiz
     }
 
     data = {
-        "sort": [{"column": "siteName", "direction": "asc"}]
     }
 
     payload = json.dumps(data)
@@ -38,7 +37,8 @@ def examplePost(secretKey="INSERT_SECRET", sharedKey="INSERT_SHARED", nepOrganiz
     res['status'] = request.status_code
     res['data'] = request.json()
 
-    print(res)
+    json_formatted = json.dumps(res, indent=2)
+    print(json_formatted)
 
     return res
 


### PR DESCRIPTION
Changed the endpoints to point at the Security service calls to get roles and to gain a login access token. Endpoints also now use Production as their environment default instead of staging. Updated in all languages with pretty-printed formatted json strings as the output. Also a few additions to the Readme.md that links to the java and dotnet examples in the Github Repository.