### PR TITLE
add postman examples

### DIFF
--- a/postman/BSP HMAC Examples.postman_collection.json
+++ b/postman/BSP HMAC Examples.postman_collection.json
@@ -1,0 +1,211 @@
+{
+	"info": {
+		"_postman_id": "62bb7d28-bcc2-4f36-9300-92073451e9d6",
+		"name": "BSP HMAC Examples",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Login (HMAC)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"//Replaces variables in header value and trims the resulting string",
+							"const processHeader = function(header) {",
+							"    if (header && header.length > 0) {",
+							"        return pm.variables.replaceIn(header).trim();",
+							"    } else {",
+							"        return header;",
+							"    }",
+							"}",
+							"",
+							"//Extracts the signable content from the request",
+							"const signableContent = function() {",
+							"    var sdk = require('postman-collection');",
+							"    var url = new sdk.Url(pm.variables.replaceIn(pm.request.url.toString()));",
+							"    var uri = encodeURI(url.getPathWithQuery());",
+							"    var headers = pm.request.getHeaders({enabled: true, ignoreCase: true});",
+							"",
+							"    const params = [",
+							"        pm.request.method,",
+							"        uri,",
+							"        processHeader(headers['content-type']),",
+							"        processHeader(headers['content-md5']),",
+							"        processHeader(headers['nep-correlation-id']),",
+							"        processHeader(headers['nep-organization']),",
+							"        processHeader(headers['nep-service-version'])",
+							"    ];",
+							"    return params.filter(p => p && p.length > 0).join('\\n');",
+							"}",
+							"",
+							"//Pull shared-key and secret-key from variables",
+							"var shared = pm.variables.get(\"shared-key\");",
+							"var secret = pm.variables.get(\"secret-key\");",
+							"",
+							"//Generate date for signing and set milliseconds to 0",
+							"var date = new Date();",
+							"date.setMilliseconds(0);",
+							"",
+							"//Compile the data to sign",
+							"var oneTimeSecret = secret +  date.toISOString();",
+							"var content = signableContent()",
+							"",
+							"//Create signature and access key value",
+							"var signature = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA512(content, oneTimeSecret));",
+							"var accessKey = shared + \":\" + signature;",
+							"",
+							"//Inject headers into request",
+							"pm.request.upsertHeader({key: \"Authorization\", value: \"AccessKey \" + accessKey, disabled: false});",
+							"pm.request.upsertHeader({key: \"Date\", value: date.toUTCString(), disabled: false});",
+							"",
+							"//Set environment variables with outputs",
+							"pm.environment.set('access-key-signature', signature);",
+							"pm.environment.set('unsigned-content-escaped', content.replace(/\\n/g, '\\\\n'));",
+							"pm.environment.set('timestamp', date.toISOString());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "nep-organization",
+						"value": "{{nep-organization}}",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "https://api.ncr.com/security/authentication/login",
+					"protocol": "https",
+					"host": [
+						"api",
+						"ncr",
+						"com"
+					],
+					"path": [
+						"security",
+						"authentication",
+						"login"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Effective Roles (Self) (HMAC)",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"//Replaces variables in header value and trims the resulting string",
+							"const processHeader = function(header) {",
+							"    if (header && header.length > 0) {",
+							"        return pm.variables.replaceIn(header).trim();",
+							"    } else {",
+							"        return header;",
+							"    }",
+							"}",
+							"",
+							"//Extracts the signable content from the request",
+							"const signableContent = function() {",
+							"    var sdk = require('postman-collection');",
+							"    var url = new sdk.Url(pm.variables.replaceIn(pm.request.url.toString()));",
+							"    var uri = encodeURI(url.getPathWithQuery());",
+							"    var headers = pm.request.getHeaders({enabled: true, ignoreCase: true});",
+							"",
+							"    const params = [",
+							"        pm.request.method,",
+							"        uri,",
+							"        processHeader(headers['content-type']),",
+							"        processHeader(headers['content-md5']),",
+							"        processHeader(headers['nep-correlation-id']),",
+							"        processHeader(headers['nep-organization']),",
+							"        processHeader(headers['nep-service-version'])",
+							"    ];",
+							"    return params.filter(p => p && p.length > 0).join('\\n');",
+							"}",
+							"",
+							"//Pull shared-key and secret-key from variables",
+							"var shared = pm.variables.get(\"shared-key\");",
+							"var secret = pm.variables.get(\"secret-key\");",
+							"",
+							"//Generate date for signing and set milliseconds to 0",
+							"var date = new Date();",
+							"date.setMilliseconds(0);",
+							"",
+							"//Compile the data to sign",
+							"var oneTimeSecret = secret +  date.toISOString();",
+							"var content = signableContent()",
+							"",
+							"//Create signature and access key value",
+							"var signature = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA512(content, oneTimeSecret));",
+							"var accessKey = shared + \":\" + signature;",
+							"",
+							"//Inject headers into request",
+							"pm.request.upsertHeader({key: \"Authorization\", value: \"AccessKey \" + accessKey, disabled: false});",
+							"pm.request.upsertHeader({key: \"Date\", value: date.toUTCString(), disabled: false});",
+							"",
+							"//Set environment variables with outputs",
+							"pm.environment.set('access-key-signature', signature);",
+							"pm.environment.set('unsigned-content-escaped', content.replace(/\\n/g, '\\\\n'));",
+							"pm.environment.set('timestamp', date.toISOString());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "default"
+					},
+					{
+						"key": "nep-organization",
+						"value": "{{nep-organization}}",
+						"type": "default"
+					}
+				],
+				"url": {
+					"raw": "https://api.ncr.com/security/role-grants/user-grants/self/effective-roles",
+					"protocol": "https",
+					"host": [
+						"api",
+						"ncr",
+						"com"
+					],
+					"path": [
+						"security",
+						"role-grants",
+						"user-grants",
+						"self",
+						"effective-roles"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,0 +1,9 @@
+# NCR BSL HMAC Postman Examples
+
+Contains a `postman-pre-request-script.js` JavaScript script that can be used in Postman to sign requests with AccessKey authorization (aka HMAC). You use it in your Postman Pre-Request Script tab in your requests.
+
+This repo also contains a Postman collection with two sample calls.
+
+### Getting Started
+
+Import `BSP HMAC Examples.postman_collection.json` into Postman and configure your `shared-key`, `secret-key`, and `nep-organization` Postman environment variables.

--- a/postman/postman-pre-request-script.js
+++ b/postman/postman-pre-request-script.js
@@ -1,0 +1,52 @@
+//Replaces variables in header value and trims the resulting string
+const processHeader = function(header) {
+    if (header && header.length > 0) {
+        return pm.variables.replaceIn(header).trim();
+    } else {
+        return header;
+    }
+}
+
+//Extracts the signable content from the request
+const signableContent = function() {
+    var sdk = require('postman-collection');
+    var url = new sdk.Url(pm.variables.replaceIn(pm.request.url.toString()));
+    var uri = encodeURI(url.getPathWithQuery());
+    var headers = pm.request.getHeaders({enabled: true, ignoreCase: true});
+
+    const params = [
+        pm.request.method,
+        uri,
+        processHeader(headers['content-type']),
+        processHeader(headers['content-md5']),
+        processHeader(headers['nep-correlation-id']),
+        processHeader(headers['nep-organization']),
+        processHeader(headers['nep-service-version'])
+    ];
+    return params.filter(p => p && p.length > 0).join('\n');
+}
+
+//Pull shared-key and secret-key from variables
+var shared = pm.variables.get("shared-key");
+var secret = pm.variables.get("secret-key");
+
+//Generate date for signing and set milliseconds to 0
+var date = new Date();
+date.setMilliseconds(0);
+
+//Compile the data to sign
+var oneTimeSecret = secret +  date.toISOString();
+var content = signableContent()
+
+//Create signature and access key value
+var signature = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA512(content, oneTimeSecret));
+var accessKey = shared + ":" + signature;
+
+//Inject headers into request
+pm.request.upsertHeader({key: "Authorization", value: "AccessKey " + accessKey, disabled: false});
+pm.request.upsertHeader({key: "Date", value: date.toUTCString(), disabled: false});
+
+//Set environment variables with outputs
+pm.environment.set('access-key-signature', signature);
+pm.environment.set('unsigned-content-escaped', content.replace(/\n/g, '\\n'));
+pm.environment.set('timestamp', date.toISOString());


### PR DESCRIPTION
# Description

This PR adds a Postman Pre-Request Script that can be used to generate NCR BSP HMAC signatures and automatically attach it to an outbound HTTP request.

It also contains a Postman Collection with an `GET` and `POST` example using the script.

## Testing

1. Import `BSP HMAC Examples.postman_collection.json` into Postman.
2. Set `shared-key`, `secret-key`, and `nep-organization` environment variables.
3. Send the sample `GET` and `POST` requests included in the collection.

## Ticket

N/A
