### PR TITLE
fix header sequence in HmacGenerator.java

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /bin/
+/.idea/

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
                              http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ncr.bsp</groupId>
-  <artifactId>junit-tests</artifactId>
+  <artifactId>ncr-bsp-hmac-java-example</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <properties>

--- a/java/src/main/java/HmacGenerator.java
+++ b/java/src/main/java/HmacGenerator.java
@@ -54,14 +54,14 @@ public class HmacGenerator {
         if (contentType != null && !contentType.isEmpty()) {
             toSign += "\n" + contentType;
         }
-        if (nepOrganization != null && !nepOrganization.isEmpty()) {
-            toSign += "\n" + nepOrganization;
-        }
         if (nepApplicationKey != null && !nepApplicationKey.isEmpty()) {
             toSign += "\n" + nepApplicationKey;
         }
         if (nepCorrelationId != null && !nepCorrelationId.isEmpty()) {
             toSign += "\n" + nepCorrelationId;
+        }
+        if (nepOrganization != null && !nepOrganization.isEmpty()) {
+            toSign += "\n" + nepOrganization;
         }
         if (nepServiceVersion != null && !nepServiceVersion.isEmpty()) {
             toSign += "\n" + nepServiceVersion;


### PR DESCRIPTION
# Description

Fix Java HMAC Generator - the required headers were in the wrong sequence in the digest

## Testing

follow readme instructions to test (unchanged)

## Ticket

N/A (bug found by Payronix)
